### PR TITLE
Fix formatting

### DIFF
--- a/src/GuildLogger.ts
+++ b/src/GuildLogger.ts
@@ -115,14 +115,29 @@ export default class GuildLogger {
    * @param meta metadata
    */
   private log = (level: LogLevel, message: string, meta?: Meta) => {
-    const { callerFunctionName, fileName } = getCallerFunctionAndFileName();
-    const extendedMeta = {
-      ...meta,
-      correlationId: this.correlator?.getId(),
-      function: callerFunctionName,
-      file: fileName,
-    };
-    this.logger?.[level]?.(message, extendedMeta);
+    try {
+      const { callerFunctionName, fileName } = getCallerFunctionAndFileName();
+      const extendedMeta = {
+        ...meta,
+        correlationId: this.correlator?.getId(),
+        function: callerFunctionName,
+        file: fileName,
+      };
+
+      this.logger?.[level]?.(message, extendedMeta);
+    } catch (error) {
+      let metaString: string;
+      try {
+        metaString = JSON.stringify(meta);
+      } catch (metaStringifyError: any) {
+        metaString = `(Cannot stringify meta: ${metaStringifyError.message})`;
+      }
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `GuildLogger.log failed with params (${level}, ${message}, ${metaString}})`
+      );
+    }
   };
 
   public error = (message: string, meta?: Meta) =>

--- a/src/GuildLogger.ts
+++ b/src/GuildLogger.ts
@@ -3,6 +3,7 @@ import { ICorrelator, GuildLoggerOptions, LogLevel, Meta } from "./types";
 import { getCallerFunctionAndFileName } from "./utils";
 
 const { printf, combine, colorize, timestamp, errors, prettyPrint } = format;
+type Format = ReturnType<typeof printf>;
 
 /**
  * Util for logging with metadata
@@ -25,9 +26,14 @@ export default class GuildLogger {
   constructor(options: GuildLoggerOptions) {
     this.correlator = options.correlator;
 
-    const logFormat = options.json
-      ? [this.getIncludeCorrelationIdFormat()(), format.json(), prettyPrint()]
-      : [colorize(), this.getPlainTextFormat()];
+    let logFormat: Format[];
+    if (options.json) {
+      logFormat = options.pretty
+        ? [this.getIncludeCorrelationIdFormat()(), format.json(), prettyPrint()]
+        : [this.getIncludeCorrelationIdFormat()(), format.json()];
+    } else {
+      logFormat = [colorize(), this.getPlainTextFormat()];
+    }
 
     this.logger = createLogger({
       level: options.level,

--- a/src/GuildLogger.ts
+++ b/src/GuildLogger.ts
@@ -32,7 +32,9 @@ export default class GuildLogger {
         ? [this.getIncludeCorrelationIdFormat()(), format.json(), prettyPrint()]
         : [this.getIncludeCorrelationIdFormat()(), format.json()];
     } else {
-      logFormat = [colorize(), this.getPlainTextFormat()];
+      logFormat = options.pretty
+        ? [colorize(), this.getPlainTextFormat()]
+        : [this.getPlainTextFormat()];
     }
 
     this.logger = createLogger({

--- a/src/GuildLogger.ts
+++ b/src/GuildLogger.ts
@@ -29,8 +29,12 @@ export default class GuildLogger {
     let logFormat: Format[];
     if (options.json) {
       logFormat = options.pretty
-        ? [this.getIncludeCorrelationIdFormat()(), format.json(), prettyPrint()]
-        : [this.getIncludeCorrelationIdFormat()(), format.json()];
+        ? [
+            this.getCustomPropertyIncludeFormat()(),
+            format.json(),
+            prettyPrint(),
+          ]
+        : [this.getCustomPropertyIncludeFormat()(), format.json()];
     } else {
       logFormat = options.pretty
         ? [colorize(), this.getPlainTextFormat()]
@@ -50,14 +54,25 @@ export default class GuildLogger {
   }
 
   /**
-   * Create a formatter that adds the correlation id to the metadata
+   * Create a formatter that adds the correlation id and error properties to the metadata
    * @returns formatter
    */
-  private getIncludeCorrelationIdFormat = () =>
+  private getCustomPropertyIncludeFormat = () =>
     format((info) => {
       const correlationId = this.correlator.getId();
+
+      let error: any;
+      if (info.error) {
+        error = {
+          name: info.error.name,
+          message: info.error.message,
+          stack: info.error.stack,
+        };
+      }
+
       return {
         ...info,
+        error,
         correlationId,
       };
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,2 +1,2 @@
 export * from "./types";
-export * from "./GuildLogger";
+export { default as GuildLogger } from "./GuildLogger";

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,4 +51,5 @@ export type Meta = {
   guild?: JustId | JustId[];
   role?: JustId | JustId[];
   params?: AnyKey;
+  error?: any;
 } & AnyKey;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type GuildLoggerOptions = {
   /**
    * suppress all logs
    */
-  silent: boolean;
+  silent?: boolean;
   /**
    * correlator instance
    */
@@ -21,6 +21,10 @@ export type GuildLoggerOptions = {
    * format log as json
    */
   json: boolean;
+  /**
+   * prettify json logs
+   */
+  pretty?: boolean;
 };
 
 type AnyKey = {

--- a/tests/GuildLogger.test.ts
+++ b/tests/GuildLogger.test.ts
@@ -86,7 +86,7 @@ describe("Check GuildLogger", () => {
 
           expect(stringData).toMatch(
             new RegExp(
-              `\\s*\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} ${testLevel} ${testCorrelationId}: ${testLogMessage}, user={\\"id\\":123}, correlationId=${testCorrelationId}, function=${testFunctionName}, file=.*fileToRun.ts:\\d{2}:\\d{2}\\n`
+              `\\s*\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\u001b\\[32m${testLevel}\\u001b\\[39m ${testCorrelationId}: ${testLogMessage}, user={\\"id\\":123}, correlationId=${testCorrelationId}, function=${testFunctionName}, file=.*fileToRun.ts:\\d{2}:\\d{2}\\n`
             )
           );
 

--- a/tests/fileToRun.ts
+++ b/tests/fileToRun.ts
@@ -8,6 +8,7 @@ const guildLogger = new GuildLogger({
   json: isJson,
   level: testLevel,
   silent: false,
+  pretty: true,
 });
 
 const testFunction = () => {


### PR DESCRIPTION
- added `pretty` option to turn on/off prettyPrint in json logs and colors in text format
- log errors properly (name, message, stack trace) in metadata (**the key should be `error` !**)
- catch all errors in `GuildLogger.log`