### PR TITLE
Fix correlationId not included in "Worker leased a job logs"

### DIFF
--- a/src/GuildLogger.ts
+++ b/src/GuildLogger.ts
@@ -3,6 +3,7 @@ import { ICorrelator, GuildLoggerOptions, LogLevel, Meta } from "./types";
 import {
   getCallerFunctionAndFileName,
   includeErrorPropertiesFormat,
+  plainTextFormat,
 } from "./utils";
 
 const { printf, combine, colorize, timestamp, errors, prettyPrint } = format;
@@ -36,8 +37,8 @@ export default class GuildLogger {
         : [includeErrorPropertiesFormat(), format.json()];
     } else {
       logFormat = options.pretty
-        ? [colorize(), this.getPlainTextFormat()]
-        : [this.getPlainTextFormat()];
+        ? [colorize(), plainTextFormat]
+        : [plainTextFormat];
     }
 
     this.logger = createLogger({
@@ -51,37 +52,6 @@ export default class GuildLogger {
       silent: options.silent,
     });
   }
-
-  /**
-   * Create a formatter for plain text logging
-   * @returns
-   */
-  private getPlainTextFormat = () =>
-    printf((log) => {
-      const correlationId = this.correlator.getId();
-      const correlationIdText = correlationId ? ` ${correlationId}` : "";
-
-      let msg = `${log.timestamp} ${log.level}${correlationIdText}: ${log.message}`;
-      let metaString = "";
-      Object.entries(log).forEach(([k, v]) => {
-        if (k === "timestamp" || k === "level" || k === "message") {
-          return;
-        }
-
-        let value: any;
-        if (v instanceof Error) {
-          value = `\n${v.stack}\n`;
-        } else if (typeof v === "object") {
-          value = JSON.stringify(v);
-        } else {
-          value = v;
-        }
-
-        metaString += `, ${k}=${value}`;
-      });
-      msg += metaString;
-      return msg;
-    });
 
   /**
    * Log a message at a given level with metadata

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,3 +32,32 @@ export const includeErrorPropertiesFormat = format((info) => {
     error,
   };
 });
+
+/**
+ * A formatter for plain text logging
+ * @returns
+ */
+export const plainTextFormat = format.printf((log) => {
+  const correlationIdText = log.correlationId ? ` ${log.correlationId}` : "";
+
+  let msg = `${log.timestamp} ${log.level}${correlationIdText}: ${log.message}`;
+  let metaString = "";
+  Object.entries(log).forEach(([k, v]) => {
+    if (k === "timestamp" || k === "level" || k === "message") {
+      return;
+    }
+
+    let value: any;
+    if (v instanceof Error) {
+      value = `\n${v.stack}\n`;
+    } else if (typeof v === "object") {
+      value = JSON.stringify(v);
+    } else {
+      value = v;
+    }
+
+    metaString += `, ${k}=${value}`;
+  });
+  msg += metaString;
+  return msg;
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { format } from "winston";
+
 // eslint-disable-next-line import/prefer-default-export
 export const getCallerFunctionAndFileName = () => {
   const stackTraceLine = new Error().stack.split("at ")?.[4]?.split(" ");
@@ -10,3 +12,23 @@ export const getCallerFunctionAndFileName = () => {
 
   return { callerFunctionName, fileName };
 };
+
+/**
+ * A formatter that adds error properties to the metadata
+ * @returns formatter
+ */
+export const includeErrorPropertiesFormat = format((info) => {
+  let error: any;
+  if (info.error) {
+    error = {
+      name: info.error.name,
+      message: info.error.message,
+      stack: info.error.stack,
+    };
+  }
+
+  return {
+    ...info,
+    error,
+  };
+});


### PR DESCRIPTION
CorrelationId is not included in "Worker leased a job" logs. 
It's important to know that it's a special case where [correlationId is explicitly added to the log's metadata](https://github.com/guildxyz/guild-queues/blob/main/src/base/Worker.ts#L192), and not retrieved from the correlator. 
When the queues were released the logging package [was also upgraded](https://github.com/guildxyz/guild-logging/commit/9defa04e472974ae7c32fd395a93362efcca614c) to support this explicit correlationId adding to the logs, but I missed something. We have a method called `getCustomPropertyIncludeFormat` and it also overwrites the `correlationId` field with `const correlationId = this.correlator.getId();`, so explicitly provided correlationIds will be overwirtten with the ones provided by the correlator. This PR mainly addresses this issue.
Instead of just removing the mentioned line from the `getCustomPropertyIncludeFormat` function, I also moved it to a util (also renamed to `includeErrorPropertiesFormat`), since it no longer uses any of the class properties thus it's not a "real method" anymore, just a util.