### PR TITLE
fix(.npmignore): support new NPM version

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,5 @@ others/
 node_modules/
 .vscode
 .env*
-src/
+/src/
 tests/

--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,7 @@ node_modules/
 .env*
 /src/
 tests/
-/.eslintignore
-/.eslintrc.json
-/.prettierrc.json
-/tsconfig.json
+.eslintignore
+.eslintrc.json
+.prettierrc.json
+tsconfig.json

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,7 @@ node_modules/
 .env*
 /src/
 tests/
+/.eslintignore
+/.eslintrc.json
+/.prettierrc.json
+/tsconfig.json


### PR DESCRIPTION
- The current LTS node uses a version of NPM (10.5.0), which introduced some changes to how the `.npmignore` file is interpreted. The `src/` entry is now evaluated recursively, therefore it ignores the src directory in the `build` directory as well after the lib is built. Changes it to `/src/` which is not evaluated recursively
- Added the config files of eslint, prettier, and typescript
- Can be tested by running `npm pack --dry-run`, without the changes, it shouldn't print the build output, therefore it gets discarded when the lib is installed in another project. With the changes, it should print the build output, the readme, and the package.json file